### PR TITLE
Multi backend support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GOPATH=$(PWD)
 
 all:	gets application
 
-test:
+test: gets
 	@go test clammit/...
 
 clean:
@@ -16,10 +16,13 @@ cleanimports:
 application:
 	@cd src/clammit && go install
 
-gets:	gcfg go-clamd
+gets:	gcfg go-clamd testify
 
 gcfg:
 	@[ -d src/gopkg.in/gcfg.v1 ] || go get gopkg.in/gcfg.v1
 
 go-clamd:
 	@[ -d src/github.com/dutchcodes/go-clamd ] || go get github.com/dutchcoders/go-clamd
+
+testify:
+	@[ -d src/gopkg.in/testify.v1 ] || go get gopkg.in/stretchr/testify.v1

--- a/clammit.cfg.example
+++ b/clammit.cfg.example
@@ -13,9 +13,9 @@
 listen          = unix:.clammit.sock
 
 #
-# URL of the application method that you will forward virus-free requests to
+# Ignore the `X-Clammit-Backend` header, and forward all requests to this application
 #
-application-url = http://localhost:9240/
+#application-url = http://localhost:9240/
 
 #
 # URL of the CLAMD server
@@ -24,10 +24,10 @@ application-url = http://localhost:9240/
 clamd-url       = unix:/var/run/clamav/clamd.ctl
 
 # Set this to a log file to redirect all output
-#log-file        = log/clammit.log
+log-file        = log/clammit.log
 
 #
 # Set this to true to have this application serve an upload form to test
 # the virus scanning
 #
-test-pages      = true
+#test-pages      = true

--- a/src/clammit/main.go
+++ b/src/clammit/main.go
@@ -9,11 +9,11 @@ package main
 import (
 	"bytes"
 	"clammit/forwarder"
-	"gopkg.in/gcfg.v1"
 	"encoding/json"
 	"flag"
 	"fmt"
 	clamd "github.com/dutchcoders/go-clamd"
+	"gopkg.in/gcfg.v1"
 	"io/ioutil"
 	"log"
 	"net"
@@ -202,18 +202,16 @@ func main() {
  * Starts logging
  */
 func startLogging() {
-	if ctx.Config.App.Debug {
-		ctx.Logger = log.New(os.Stdout, "", log.LstdFlags)
-		if ctx.Config.App.Logfile != "" {
-			w, err := os.OpenFile(ctx.Config.App.Logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0660)
-			if err == nil {
-				ctx.Logger = log.New(w, "", log.LstdFlags)
-			} else {
-				log.Fatal("Failed to open log file", ctx.Config.App.Logfile, ":", err)
-			}
+	if ctx.Config.App.Logfile != "" {
+		w, err := os.OpenFile(ctx.Config.App.Logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0660)
+		if err == nil {
+			ctx.Logger = log.New(w, "", log.LstdFlags)
+		} else {
+			log.Fatal("Failed to open log file", ctx.Config.App.Logfile, ":", err)
 		}
 	} else {
-		ctx.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+		ctx.Logger = log.New(os.Stdout, "", log.LstdFlags)
+		ctx.Logger.Println("No log file configured - using stdout")
 	}
 }
 
@@ -330,7 +328,7 @@ func scanForwardHandler(w http.ResponseWriter, req *http.Request) {
 	defer func() { ctx.ActivityChan <- -1 }()
 
 	fw := forwarder.NewForwarder(ctx.ApplicationURL, ctx.Config.App.ContentMemoryThreshold, ctx.ClamInterceptor)
-	fw.SetLogger(ctx.Logger)
+	fw.SetLogger(ctx.Logger, ctx.Config.App.Debug)
 	fw.HandleRequest(w, req)
 }
 


### PR DESCRIPTION
This adds support for multiple backends, so only a single instance of Clammit needs to be running instead of one per application.

By default it works the same as it does now, using the `application-url` configuration option, however if that is omitted it will look at the `X-Clammit-Backend` HTTP headers to for which backend to support. Here is an example Nginx configuration:

```nginx
location ~ ^/documents/(.*) {
  proxy_set_header X-Clammit-Backend unix:$my_app/.sock;
  proxy_pass http://unix:$clammit_app/.sock;
}
```

The header is only checked if the `application-url` option is missing, so as long as the header is set in Nginx it can't be used to proxy to arbitrary hosts. I was considering having the backend URLs stored in the clammit config, and then the header just being a key to select the backend, but I like this way better as it means the configuration only needs to be done on the HTTP server.