### PR TITLE
using goreleaser for releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/*
+dist/*
 pkg/*
 src/gopkg.in/*
 src/github.com/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 go:
-  - 1.5
-  - 1.6
+  - 1.8
 
 language: go
 
@@ -9,3 +8,6 @@ install:
 
 script:
   - make test
+
+after_success:
+  test -n "$TRAVIS_TAG" && make release

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,6 @@ gcfg:
 
 testify:
 	[ -d src/gopkg.in/testify.v1 ] || go get gopkg.in/stretchr/testify.v1
+
+release:
+	curl -sL https://git.io/goreleaser | bash

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,9 @@
+build:
+  main: clammit
+  binary_name: clammit
+  goos:
+    - linux
+  goarch:
+    - amd64
+    - arm
+    - arm64


### PR DESCRIPTION
Each time a new tag is created in the repo, travis will publish a new release, along with the release artifacts. You only need to setup a `GITHUB_TOKEN` environment variable in Travis, following the instructions [here](https://github.com/goreleaser/goreleaser#environment-setup).

[Here](https://github.com/atzoum/clammit/releases/tag/v0.1.3) is an example release from my repo.

PS. upgraded go version to 1.8 inside `travis.yml`