### PR TITLE
removed hardcoded logfile from bin to accept parameter from configuration

### DIFF
--- a/bin/start_clammit
+++ b/bin/start_clammit
@@ -5,7 +5,4 @@ BASE=$(dirname "$0")
 CFG="${BASE}/../etc/clammit.cfg"
 [ -f "$CFG" ] || { echo "Missing config: $CFG"; exit 1; }
 
-mkdir -p "${BASE}/log"
-LOGFILE="${BASE}/log/clammit.log"
-
-$(dirname $0)/clammit -config=$CFG >>"${LOGFILE}" 2>&1 & disown -h
+$(dirname $0)/clammit -config=$CFG & disown -h


### PR DESCRIPTION
Logs were not written to stdout even if log-file variable was not mentioned before this commit.
