### PR TITLE
Fix: X-Forwarded-For double-use and no comma

### DIFF
--- a/src/clammit/forwarder/forwarder.go
+++ b/src/clammit/forwarder/forwarder.go
@@ -175,7 +175,7 @@ func (f *Forwarder) forwardRequest(req *http.Request, body io.Reader, contentLen
 		if xff != "" {
 			xff += ", "
 		}
-		xff += req.Header.Get("X-Forwarded-For") + strings.Split(req.RemoteAddr, ":")[0]
+		xff += strings.Split(req.RemoteAddr, ":")[0]
 		freq.Header.Set("X-Forwarded-For", xff)
 	}
 


### PR DESCRIPTION
The forwarder attempts to extend, or create, the `X-Forwarded-For` header. However, the logic is slightly broken and breaks the header. It does:

1. Initialise `xff` to the original header value.
1. If it's non-empty, append `, ` to it.
1. Append the original header *again*, plus clammit's own IP *without* any comma separation

So, in this pull request I've dealt with both of those issues with a simple modification.

HTH,
Steve.