### PR TITLE
Fix: Copy the Host header

### DIFF
--- a/src/clammit/forwarder/forwarder.go
+++ b/src/clammit/forwarder/forwarder.go
@@ -165,6 +165,7 @@ func (f *Forwarder) forwardRequest(req *http.Request, body io.Reader, contentLen
 	client, url := f.getClient(req)
 	freq, _ := http.NewRequest(req.Method, url.String(), body)
 	freq.ContentLength = contentLength
+	freq.Host = req.Host
 	for key, val := range req.Header {
 		freq.Header[key] = val
 	}

--- a/src/clammit/forwarder/forwarder.go
+++ b/src/clammit/forwarder/forwarder.go
@@ -97,7 +97,7 @@ func (f *Forwarder) HandleRequest(w http.ResponseWriter, req *http.Request) {
 	//
 	bodyHolder, err := NewBodyHolder(req.Body, req.ContentLength, f.contentMemoryThreshold)
 	if err != nil {
-		f.logger.Println("Unable to save body to local store: %s", err.Error())
+		f.logger.Println("Unable to save body to local store:", err.Error())
 		http.Error(w, "Internal Server Error", 500)
 		return
 	}

--- a/src/clammit/forwarder/forwarder_test.go
+++ b/src/clammit/forwarder/forwarder_test.go
@@ -55,7 +55,7 @@ func TestInterceptor(t *testing.T) {
 		if n, err := body.Read(buf); err != nil && err != io.EOF {
 			t.Fatalf("Got error reading body: %s", err.Error())
 		} else if string(buf[0:n]) != bodyText {
-			t.Fatalf("Read body failed: X%vX, expected X%vX %v", string(buf[0:n]), bodyText)
+			t.Fatalf("Read body failed: X%vX, expected X%vX", string(buf[0:n]), bodyText)
 		}
 		w.Header().Set("foo", "bar")
 		w.WriteHeader(204)
@@ -103,7 +103,7 @@ func TestForwarding(t *testing.T) {
 		if body, err := ioutil.ReadAll(r.Body); err != nil {
 			t.Fatal("Unexpected error reading request body:", err)
 		} else if string(body) != requestText {
-			t.Fatal("Request body is %s, expected %s", string(body), requestText)
+			t.Fatalf("Request body is %s, expected %s", string(body), requestText)
 		}
 		w.Header().Add("foo", "bar")
 		w.WriteHeader(202)

--- a/src/clammit/forwarder/forwarder_test.go
+++ b/src/clammit/forwarder/forwarder_test.go
@@ -132,6 +132,54 @@ func TestForwarding(t *testing.T) {
 	}
 }
 
+func TestHostForwarding(t *testing.T) {
+	requestText := "This is a request"
+	responseText := "This is the response"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostname := strings.Split(r.Host, ":")[0]
+		if hostname != "localhost" {
+			t.Fatalf("Host field incorrect: %v, expected %v", hostname, "localhost")
+		}
+		defer r.Body.Close()
+		w.WriteHeader(202)
+		w.Write([]byte(responseText))
+	}))
+	defer ts.Close()
+	tsURL, _ := url.Parse(ts.URL)
+
+	fw := NewForwarder(tsURL, 10000, nil)
+
+	req, _ := http.NewRequest("POST", "http://localhost:99999/bar?crazy=true", strings.NewReader(requestText))
+	req.Header.Set("myheader", "headervalue")
+	req.RemoteAddr = "foobar:1234"
+	w := NewTestResponseWriter()
+
+	fw.HandleRequest(w, req)
+
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostname := strings.Split(r.Host, ":")[0]
+		if hostname != "testhost" {
+			t.Fatalf("Host field incorrect: %v, expected %v", hostname, "testhost")
+		}
+		defer r.Body.Close()
+		w.WriteHeader(202)
+		w.Write([]byte(responseText))
+	}))
+	defer ts.Close()
+	tsURL, _ = url.Parse(ts.URL)
+
+	fw = NewForwarder(tsURL, 10000, nil)
+
+	req, _ = http.NewRequest("POST", "http://localhost:99999/bar?crazy=true", strings.NewReader(requestText))
+	req.Host = "testhost"
+	req.Header.Set("myheader", "headervalue")
+	req.RemoteAddr = "foobar:1234"
+	w = NewTestResponseWriter()
+
+	fw.HandleRequest(w, req)
+}
+
 func TestMutliForwarder(t *testing.T) {
 	requestText := "This is a request"
 

--- a/src/clammit/main.go
+++ b/src/clammit/main.go
@@ -155,7 +155,7 @@ func main() {
 		if sp, err := strconv.ParseInt(ctx.Config.App.SocketPerms, 8, 0); err == nil {
 			socketPerms = int(sp)
 		} else {
-			log.Fatalf("SocketPerms invalid (expected 4-digit octal: %s", err.Error)
+			log.Fatalf("SocketPerms invalid (expected 4-digit octal: %s", err.Error())
 		}
 	}
 

--- a/src/clammit/scan_interceptor_test.go
+++ b/src/clammit/scan_interceptor_test.go
@@ -129,7 +129,7 @@ func makeMultipartBody() (*bytes.Buffer, string) {
 
 	err := writer.Close()
 	if err != nil {
-		log.Fatal("Can't close multipart writer: %v", err)
+		log.Fatal("Can't close multipart writer:", err)
 	}
 
 	return body, writer.FormDataContentType()
@@ -138,12 +138,12 @@ func makeMultipartBody() (*bytes.Buffer, string) {
 func addPart(w *multipart.Writer, name, fileName string) {
 	part, err := w.CreateFormFile(name, fileName)
 	if err != nil {
-		log.Fatal("Cannot create multipart body: %v", err)
+		log.Fatal("Cannot create multipart body:", err)
 	}
 
 	_, err = io.WriteString(part, name)
 	if err != nil {
-		log.Fatal("Can't write part to multipart body: %v", err)
+		log.Fatal("Can't write part to multipart body:", err)
 	}
 	return
 }

--- a/src/clammit/scanner/clamav.go
+++ b/src/clammit/scanner/clamav.go
@@ -18,7 +18,7 @@ func (c *Clamav) SetAddress(url string) {
 	c.clam = clamd.NewClamd(url)
 
 	if c.debug {
-		c.logger.Println("Initialised clamav connection to %s", url)
+		c.logger.Println("Initialised clamav connection to", url)
 	}
 }
 


### PR DESCRIPTION
Some backends need to know the originally requested host. Clammit tries to copy all headers. However, as per the [`net/http` docs](https://golang.org/pkg/net/http/):

> For incoming requests, the Host header is promoted to the Request.Host field and removed from the Header map.

So, we need to try copying the `Request.Host` field as well as all entries in `Request.Header`.