### PR TITLE
Fix: Don't follow redirects, return them

### DIFF
--- a/src/clammit/forwarder/forwarder.go
+++ b/src/clammit/forwarder/forwarder.go
@@ -231,6 +231,10 @@ func (f *Forwarder) getClient(req *http.Request) (*http.Client, *url.URL) {
 		}, url
 	} else {
 		f.logger.Printf("Forwarding to %s", applicationURL.String())
-		return &http.Client{}, url
+		return &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}, url
 	}
 }


### PR DESCRIPTION
A reverse proxy shouldn't follow redirects automatically (usually). This is because the current implementation takes the incoming request and creates a new client, copying the old request material over. By default a new HTTP client in Go will follow redirects. This, however, can be [overridden](https://golang.org/pkg/net/http/#Client) by returning `ErrUseLastResponse` in `Client`'s `CheckRedirect` function.

A basic test I wrote for this didn't work (it succeeds even with the bug present), so I think the way the test clients are constructed and talk to the forwarder would need some work in order to construct a proper test. Whether that's necessary or not, I'll defer to project owner's judgement.