### PR TITLE
Preventing the forwarded request from following redirects

### DIFF
--- a/src/clammit/forwarder/forwarder.go
+++ b/src/clammit/forwarder/forwarder.go
@@ -180,6 +180,9 @@ func (f *Forwarder) forwardRequest(req *http.Request, body io.Reader, contentLen
 		freq.Header.Set("X-Forwarded-For", xff)
 	}
 
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	return client.Do(freq)
 }
 


### PR DESCRIPTION
This change is to ensure that any POST redirect are respected by the
client, rather than being considered a part of the forwarded request
that needs to be resolved.