### PR TITLE
Fix the module definition in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module clammit
+module github.com/ifad/clammit
 
 go 1.21
 


### PR DESCRIPTION
Hello,

The module definition in go.mod should contain the import path of the module, and not only the package name. Otherwise it prevents it from being "go install"ed:

$ go install github.com/ifad/clammit@latest
go: downloading github.com/ifad/clammit v0.8.1
go: github.com/ifad/clammit@latest: version constraints conflict:
        github.com/ifad/clammit@v0.8.1: parsing go.mod:
        module declares its path as: clammit
                but was required as: github.com/ifad/clammit

Here is the relevant specification in the go definition:

- https://go.dev/doc/modules/gomod-ref#module
- https://go.dev/ref/mod#go-mod-file-module

> Syntax
> module module-path
>
> module-path
> The module's module path, usually the repository location from which the module can be downloaded by Go tools.

Regards,